### PR TITLE
fix: add new "FOURC_*" env variable for setting log level

### DIFF
--- a/__tests__/logger.js
+++ b/__tests__/logger.js
@@ -11,7 +11,7 @@ describe('logging', () => {
     global.console = { log: logSpy, error: errorSpy };
 
     // turn off color for easier asserts
-    process.env['4C_LOGGING_USE_COLOR'] = false;
+    process.env['FOURC_LOGGING_USE_COLOR'] = false;
 
     delete process.env.NODE_ENV;
     logging = require('../index');

--- a/createLogging.js
+++ b/createLogging.js
@@ -29,7 +29,11 @@ module.exports = function createLogging({
 } = {}) {
   const container = new Container();
   const TEST = Env.get('NODE_ENV', '') === 'test';
-  const useColor = Env.get.boolish('4C_LOGGING_USE_COLOR', true);
+
+  let useColor = Env.get.boolish('4C_LOGGING_USE_COLOR', null);
+  if (!useColor) {
+    useColor = Env.get.boolish('FOURC_LOGGING_USE_COLOR', true);
+  }
 
   // TODO: deprecate this as number prefixed env variables aren't standard
   let LEVEL = Env.get('4C_LOGGING_LEVEL', null);

--- a/createLogging.js
+++ b/createLogging.js
@@ -36,10 +36,9 @@ module.exports = function createLogging({
     : Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
-  let LEVEL = Env.get('4C_LOGGING_LEVEL', null);
-  if (!LEVEL) {
-    LEVEL = Env.get('FOURC_LOGGING_LEVEL', 'info');
-  }
+  const LEVEL = Env.get('4C_LOGGING_LEVEL', null) === null
+    ? Env.get('FOURC_LOGGING_LEVEL', 'info')
+    : Env.get('4C_LOGGING_LEVEL', 'info');
 
   const appendMeta = format(i => {
     const { level: _, message: _a, label: _b, ...meta } = i;

--- a/createLogging.js
+++ b/createLogging.js
@@ -32,13 +32,13 @@ module.exports = function createLogging({
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
   const useColor =
-    Env.get('4C_LOGGING_USE_COLOR', null) === null
+    Env.get('4C_LOGGING_USE_COLOR', null) === 'null'
       ? Env.get.boolish('FOURC_LOGGING_USE_COLOR', true)
       : Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
   let LEVEL =
-    Env.get('4C_LOGGING_LEVEL', null) === null
+    Env.get('4C_LOGGING_LEVEL', null) === 'null'
       ? Env.get('FOURC_LOGGING_LEVEL', 'info')
       : Env.get('4C_LOGGING_LEVEL', 'info');
 

--- a/createLogging.js
+++ b/createLogging.js
@@ -31,7 +31,11 @@ module.exports = function createLogging({
   const TEST = Env.get('NODE_ENV', '') === 'test';
   const useColor = Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
-  let LEVEL = Env.get('4C_LOGGING_LEVEL', 'info');
+  // TODO: deprecate this as number prefixed env variables aren't standard
+  let LEVEL = Env.get('4C_LOGGING_LEVEL', null);
+  if (!LEVEL) {
+    LEVEL = Env.get('FOURC_LOGGING_LEVEL', 'info');
+  }
 
   const appendMeta = format(i => {
     const { level: _, message: _a, label: _b, ...meta } = i;

--- a/createLogging.js
+++ b/createLogging.js
@@ -31,14 +31,16 @@ module.exports = function createLogging({
   const TEST = Env.get('NODE_ENV', '') === 'test';
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
-  const useColor = Env.get('4C_LOGGING_USE_COLOR', null) === null
-    ? Env.get.boolish('FOURC_LOGGING_USE_COLOR', true)
-    : Env.get.boolish('4C_LOGGING_USE_COLOR', true);
+  const useColor =
+    Env.get('4C_LOGGING_USE_COLOR', null) === null
+      ? Env.get.boolish('FOURC_LOGGING_USE_COLOR', true)
+      : Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
-  const LEVEL = Env.get('4C_LOGGING_LEVEL', null) === null
-    ? Env.get('FOURC_LOGGING_LEVEL', 'info')
-    : Env.get('4C_LOGGING_LEVEL', 'info');
+  let LEVEL =
+    Env.get('4C_LOGGING_LEVEL', null) === null
+      ? Env.get('FOURC_LOGGING_LEVEL', 'info')
+      : Env.get('4C_LOGGING_LEVEL', 'info');
 
   const appendMeta = format(i => {
     const { level: _, message: _a, label: _b, ...meta } = i;

--- a/createLogging.js
+++ b/createLogging.js
@@ -30,12 +30,12 @@ module.exports = function createLogging({
   const container = new Container();
   const TEST = Env.get('NODE_ENV', '') === 'test';
 
-  let useColor = Env.get.boolish('4C_LOGGING_USE_COLOR', null);
-  if (!useColor) {
-    useColor = Env.get.boolish('FOURC_LOGGING_USE_COLOR', true);
-  }
+  // TODO: deprecate 4C_* as number prefixed env variables aren't standard
+  const useColor = Env.get('4C_LOGGING_USE_COLOR', null) === null
+    ? Env.get.boolish('FOURC_LOGGING_USE_COLOR', true)
+    : Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
-  // TODO: deprecate this as number prefixed env variables aren't standard
+  // TODO: deprecate 4C_* as number prefixed env variables aren't standard
   let LEVEL = Env.get('4C_LOGGING_LEVEL', null);
   if (!LEVEL) {
     LEVEL = Env.get('FOURC_LOGGING_LEVEL', 'info');


### PR DESCRIPTION
Number prefixed environment variables aren't standard I believe. I ran into issues with this on my shell.

Adding new `FOURC_LOGGING_LEVEL` fallback env variable