### PR TITLE
fix: use explicit FOURC_SILENCE_LOGGING for silencing logging

### DIFF
--- a/createLogging.js
+++ b/createLogging.js
@@ -28,7 +28,7 @@ module.exports = function createLogging({
   Transport = transports.Console,
 } = {}) {
   const container = new Container();
-  const silenceLogger = Env.get.boolish('FOURC_SILENCE_LOGGING', true);
+  const silenceLogger = Env.get.boolish('FOURC_SILENCE_LOGGING', Env.get('NODE_ENV', '') === 'test');
 
   // TODO: deprecate 4C_* as number prefixed env variables aren't standard
   const useColor =

--- a/createLogging.js
+++ b/createLogging.js
@@ -28,7 +28,7 @@ module.exports = function createLogging({
   Transport = transports.Console,
 } = {}) {
   const container = new Container();
-  const TEST = Env.get('NODE_ENV', '') === 'test';
+  const silenceLogger = Env.get.boolish('FOURC_SILENCE_LOGGING', false);
   const useColor = Env.get.boolish('4C_LOGGING_USE_COLOR', true);
 
   let LEVEL = Env.get('4C_LOGGING_LEVEL', 'info');
@@ -64,7 +64,7 @@ module.exports = function createLogging({
     container.add(id, {
       level: LEVEL,
       format: defaultFormat(label),
-      transports: [new Transport({ silent: TEST })],
+      transports: [new Transport({ silent: silenceLogger })],
     });
     const logger = container.get(id);
     logger.createLogger = createLogger;


### PR DESCRIPTION
I think being explicit makes more sense, no?

Tries to address #5 

Technically breaking and not sure what impact it has on current usages though...