### PR TITLE
feat: pass formatter to createLogger; separate meta attribute

### DIFF
--- a/createLogging.js
+++ b/createLogging.js
@@ -63,20 +63,19 @@ module.exports = function createLogging({
     return i;
   });
 
-  const defaultFormat = ({ label }) =>
-    combine(
-      ...[
-        useColor && colorize(),
-        label && addLabel({ label, message: true }),
-        appendMeta(),
-        printf((i) => `${i.level}:  ${i.message}`),
-      ].filter(Boolean),
-    );
+  const defaultFormatter = printf((i) => `${i.level}:  ${i.message}`);
 
-  function createLogger(id, label = id, formatter = defaultFormat) {
+  function createLogger(id, label = id, formatter = defaultFormatter) {
     container.add(id, {
       level: LEVEL,
-      format: formatter({ label, id }),
+      format: combine(
+        ...[
+          useColor && colorize(),
+          label && addLabel({ label, message: true }),
+          appendMeta(),
+          formatter,
+        ].filter(Boolean),
+      ),
       transports: [new Transport({ silent: silenceLogger })],
     });
     const logger = container.get(id);

--- a/createLogging.js
+++ b/createLogging.js
@@ -54,16 +54,18 @@ module.exports = function createLogging({
 
     if (!Object.keys(meta).length) return i;
     // eslint-disable-next-line
-    i.message = `${i.message}:\t${inspect(meta, {
+    i.meta = inspect(meta, {
       showProxy: true,
       depth: 2,
       maxArrayLength: 5,
-      colors: true,
-    })}`;
+      colors: useColor,
+    });
     return i;
   });
 
-  const defaultFormatter = printf((i) => `${i.level}:  ${i.message}`);
+  const defaultFormatter = printf(
+    (i) => `${i.level}:  ${i.message}${i.meta && `\t${i.meta}`}`,
+  );
 
   function createLogger(id, label = id, formatter = defaultFormatter) {
     container.add(id, {

--- a/createLogging.js
+++ b/createLogging.js
@@ -53,6 +53,7 @@ module.exports = function createLogging({
     delete meta[Symbol.for('splat')];
 
     if (!Object.keys(meta).length) return i;
+
     // eslint-disable-next-line
     i.meta = inspect(meta, {
       showProxy: true,
@@ -60,12 +61,14 @@ module.exports = function createLogging({
       maxArrayLength: 5,
       colors: useColor,
     });
+
     return i;
   });
 
-  const defaultFormatter = printf(
-    (i) => `${i.level}:  ${i.message}${i.meta && `\t${i.meta}`}`,
-  );
+  const defaultFormatter = printf((i) => {
+    const message = `${i.level}:  ${i.message}`;
+    return i.meta ? `${message}\t${i.meta}` : message;
+  });
 
   function createLogger(id, label = id, formatter = defaultFormatter) {
     container.add(id, {


### PR DESCRIPTION
This approach is probably a little cleaner, and it lets external formatters take advantage of benefits that are internal to this library